### PR TITLE
fix: make exportWebsite idempotent against Jahia server-directory validation

### DIFF
--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
@@ -144,6 +144,11 @@ public class WebsitesMutation {
                 LOGGER.error("exportWebsite: exportPath '{}' resolves outside the allowed exports directory", exportPath);
                 return Boolean.FALSE;
             }
+            // Jahia rejects a server export directory that already contains files
+            // (ImportExportBaseService.isValidServerDirectory requires it to be empty or
+            // non-existent). Remove any previous export at this path so repeated exports
+            // to the same exportPath are idempotent instead of failing with a 403.
+            FileUtils.deleteQuietly(resolvedExportPath.toFile());
             final Map<String, Object> params = new HashMap<>(6);
             params.put(ImportExportService.VIEW_CONTENT, true);
             params.put(ImportExportService.VIEW_VERSION, false);


### PR DESCRIPTION
## Summary

`exportWebsite` fails (returns `false`) on the second and later calls to the same `exportPath`, breaking the Cypress E2E suite (was 4/5).

## Root cause

Jahia 8.2's `ImportExportBaseService.isValidServerDirectory` requires the `SERVER_DIRECTORY` export target to be **empty or non-existent** (verified in Jahia core source). `exportWebsite` writes to a fixed directory and never clears it, so the first export populates it and the next export to the same path is rejected with `JahiaForbiddenAccessException` ("failed the validation check", 403). `@GraphQLAsync` + Cypress assertion retries re-fire the mutation against the now-non-empty directory, so the test observes `false`.

## Change

Delete the resolved target directory (already confined to the exports root by the existing path-traversal guard) via `FileUtils.deleteQuietly` before calling `exportSites`, making repeated exports idempotent.

## Test plan

- `mvn clean install` succeeds.
- Full Cypress E2E suite **green (5/5)** against Jahia EE 8.2, including `exports a website via GraphQL and returns true`.
- No `failed the validation check` / 403 in the Jahia server log after the change.