### PR TITLE
fix(deps): AWS SDK 2.46.5 + explicit slf4j-api (supersedes #11/#12/#13)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>2.20.94</version>
+            <version>2.46.5</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -67,12 +67,21 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3-transfer-manager</artifactId>
-            <version>2.20.94</version>
+            <version>2.46.5</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.29.6</version>
+            <version>0.47.0</version>
+        </dependency>
+        <!-- Declared explicitly (provided by Jahia at runtime): the code uses org.slf4j
+             directly and the AWS SDK no longer supplies slf4j-api transitively on the
+             compile classpath since the s3 artifact excludes it. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.16</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
Replaces Dependabot PRs #11, #12, #13 (AWS SDK bumps) which each fail to build.

## Root cause
The `s3` dependency excludes `slf4j-api` (so it is not bundled into the OSGi module — Jahia provides it at runtime). The module relied on the *other* AWS artifacts to bring `slf4j-api` onto the compile classpath. AWS SDK 2.46.x no longer does, so the build fails with `cannot find symbol: org.slf4j.Logger`. The three AWS artifacts are also version-coupled, so they must move together.

## Change
- `software.amazon.awssdk:s3` 2.20.94 → **2.46.5**
- `software.amazon.awssdk:s3-transfer-manager` 2.20.94 → **2.46.5**
- `software.amazon.awssdk.crt:aws-crt` 0.29.6 → **0.47.0**
- Declare `org.slf4j:slf4j-api` explicitly with `provided` scope (compile-time only; Jahia provides it at runtime)

## Test plan
- [x] `mvn clean install` (compile + unit tests) passes