### PR TITLE
fix(security): harden site import/export path containment and null safety

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,22 @@
             <version>2.0.16</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Test scope. JUnit 4 is used deliberately: the jahia-modules parent pins the
+             surefire-junit4 provider, so a JUnit 5/Jupiter test would compile but report
+             "Tests run: 0" (silently skipped). -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.26.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurity.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurity.java
@@ -1,0 +1,48 @@
+package org.jahia.community.graphql.provider.dxm.extensions.websites;
+
+import java.nio.file.Path;
+
+/**
+ * Path containment helpers shared by the website export/import mutations.
+ *
+ * <p>All user-supplied path fragments coming from GraphQL input (export path, import path,
+ * site key) are untrusted and may contain {@code ..} segments or absolute escapes. These
+ * helpers resolve a child against a trusted base directory and verify that the canonical
+ * result stays inside that base, rejecting any traversal attempt.
+ */
+final class PathSecurity {
+
+    private PathSecurity() {
+        // utility class
+    }
+
+    /**
+     * Resolves {@code child} against {@code baseDir} and verifies the normalized result is
+     * contained within {@code baseDir}.
+     *
+     * @param baseDir trusted, already-normalized absolute base directory
+     * @param child   untrusted relative fragment from external input (may be {@code null})
+     * @return the normalized, contained absolute path
+     * @throws IllegalArgumentException if {@code child} is null/blank or escapes {@code baseDir}
+     */
+    static Path resolveContained(Path baseDir, String child) {
+        if (child == null || child.trim().isEmpty()) {
+            throw new IllegalArgumentException("Path fragment must not be null or blank");
+        }
+        final Path resolved = baseDir.resolve(child).normalize();
+        if (!isContained(baseDir, resolved)) {
+            throw new IllegalArgumentException(
+                    "Path fragment '" + child + "' resolves outside the allowed directory");
+        }
+        return resolved;
+    }
+
+    /**
+     * @return {@code true} when {@code candidate} is {@code baseDir} itself or a descendant of it.
+     */
+    static boolean isContained(Path baseDir, Path candidate) {
+        final Path normalizedBase = baseDir.normalize();
+        final Path normalizedCandidate = candidate.normalize();
+        return normalizedCandidate.startsWith(normalizedBase);
+    }
+}

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
@@ -65,6 +65,8 @@ public class WebsitesMutation {
     private static final String SHARED_FILES = "/shared/files/";
     private static final String SHARED_MASHUPS = "/shared/mashups/";
     private static final String SITES_PATH_PREFIX = "/sites/"; // NOSONAR java:S1075
+    private static final double S3_TARGET_THROUGHPUT_GBPS = 20.0;
+    private static final long S3_MINIMUM_PART_SIZE_BYTES = 8L * SizeConstant.MB;
 
     @GraphQLField
     @GraphQLDescription("Create a website")
@@ -139,9 +141,16 @@ public class WebsitesMutation {
         try {
             final SettingsBean settingsBean = BundleUtils.getOsgiService(SettingsBean.class, null);
             final Path exportsBaseDir = Paths.get(settingsBean.getJahiaVarDiskPath(), "exports").toAbsolutePath().normalize();
-            final Path resolvedExportPath = exportsBaseDir.resolve(exportPath).normalize();
-            if (!resolvedExportPath.startsWith(exportsBaseDir)) {
-                LOGGER.error("exportWebsite: exportPath '{}' resolves outside the allowed exports directory", exportPath);
+            final Path resolvedExportPath;
+            try {
+                resolvedExportPath = PathSecurity.resolveContained(exportsBaseDir, exportPath);
+            } catch (IllegalArgumentException ex) {
+                LOGGER.error("exportWebsite: rejected exportPath '{}': {}", exportPath, ex.getMessage());
+                return Boolean.FALSE;
+            }
+            final JahiaSite site = ServicesRegistry.getInstance().getJahiaSitesService().getSiteByKey(siteKey);
+            if (site == null) {
+                LOGGER.error("exportWebsite: site '{}' not found", siteKey);
                 return Boolean.FALSE;
             }
             // Jahia rejects a server export directory that already contains files
@@ -168,10 +177,11 @@ public class WebsitesMutation {
             params.put(ImportExportService.XSL_PATH, cleanupXsl);
 
             final List<JCRSiteNode> siteList = new ArrayList<>();
-            final JahiaSite site = ServicesRegistry.getInstance().getJahiaSitesService().getSiteByKey(siteKey);
             siteList.add((JCRSiteNode) site);
             final ImportExportBaseService importExportBaseService = ServicesRegistry.getInstance().getImportExportService();
-            importExportBaseService.exportSites(new ByteArrayOutputStream(), params, siteList);
+            try (ByteArrayOutputStream exportSink = new ByteArrayOutputStream()) {
+                importExportBaseService.exportSites(exportSink, params, siteList);
+            }
             return Boolean.TRUE;
         } catch (JahiaException | RepositoryException | IOException | SAXException | TransformerException ex) {
             LOGGER.error(String.format("Impossible to export website %s", siteKey), ex);
@@ -187,9 +197,13 @@ public class WebsitesMutation {
         LOGGER.info("Processing Import");
         Boolean successful = Boolean.TRUE;
         final Path importsBaseDir = Paths.get(BundleUtils.getOsgiService(SettingsBean.class, null).getJahiaImportsDiskPath()).toAbsolutePath().normalize();
-        final Path absoluteImportPath = importsBaseDir.resolve(importPath).normalize();
-        if (!absoluteImportPath.startsWith(importsBaseDir)) {
-            LOGGER.error("importWebsite: importPath '{}' resolves outside the allowed imports directory", importPath);
+        final Path absoluteImportPath;
+        try {
+            absoluteImportPath = PathSecurity.resolveContained(importsBaseDir, importPath);
+            // siteKey is untrusted GraphQL input used as a directory name; reject traversal.
+            PathSecurity.resolveContained(absoluteImportPath, siteKey);
+        } catch (IllegalArgumentException ex) {
+            LOGGER.error("importWebsite: rejected import location (importPath '{}', siteKey '{}'): {}", importPath, siteKey, ex.getMessage());
             return Boolean.FALSE;
         }
         try (InputStream input = new FileInputStream(Paths.get(absoluteImportPath.toString(), "export.properties").toString())) {
@@ -279,6 +293,10 @@ public class WebsitesMutation {
                     infos.getType(),
                     new Version(infos.getOriginatingJahiaRelease()));
             final JahiaSite system = jahiaSitesService.getSiteByKey(JahiaSitesService.SYSTEM_SITE_KEY);
+            if (system == null) {
+                LOGGER.error("Cannot import files: system site '{}' not found", JahiaSitesService.SYSTEM_SITE_KEY);
+                return;
+            }
 
             final Map<String, String> pathMapping = JCRSessionFactory.getInstance()
                     .getCurrentUserSession().getPathMapping();
@@ -416,8 +434,8 @@ public class WebsitesMutation {
                 .s3Client(S3AsyncClient.crtBuilder()
                         .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(awsS3AccessKey, awsS3SecretAccessKey)))
                         .region(Region.of(awsS3Region))
-                        .targetThroughputInGbps(20.0)
-                        .minimumPartSizeInBytes(8 * SizeConstant.MB)
+                        .targetThroughputInGbps(S3_TARGET_THROUGHPUT_GBPS)
+                        .minimumPartSizeInBytes(S3_MINIMUM_PART_SIZE_BYTES)
                         .build())
                 .build()) {
             LOGGER.info("ETag: {}", s3TransferManager.uploadFile(builder -> builder.putObjectRequest(b -> b.bucket(awsS3BucketName).key(exportFile.getFileName().toString()))

--- a/src/test/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurityTest.java
+++ b/src/test/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurityTest.java
@@ -1,0 +1,87 @@
+package org.jahia.community.graphql.provider.dxm.extensions.websites;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link PathSecurity}, the containment guard protecting the website
+ * export/import mutations against path traversal from untrusted GraphQL input.
+ */
+public class PathSecurityTest {
+
+    private final Path baseDir = Paths.get("/var/jahia/exports").toAbsolutePath().normalize();
+
+    @Test
+    public void resolveContained_simpleChild_returnsContainedPath() {
+        // Arrange / Act
+        Path resolved = PathSecurity.resolveContained(baseDir, "my-site");
+
+        // Assert
+        assertThat(resolved).isEqualTo(baseDir.resolve("my-site"));
+        assertThat(PathSecurity.isContained(baseDir, resolved)).isTrue();
+    }
+
+    @Test
+    public void resolveContained_nestedChild_returnsContainedPath() {
+        Path resolved = PathSecurity.resolveContained(baseDir, "a/b/c");
+
+        assertThat(resolved).isEqualTo(baseDir.resolve("a/b/c"));
+    }
+
+    @Test
+    public void resolveContained_parentTraversal_isRejected() {
+        assertThatThrownBy(() -> PathSecurity.resolveContained(baseDir, "../../etc/passwd"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("outside the allowed directory");
+    }
+
+    @Test
+    public void resolveContained_traversalAfterValidPrefix_isRejected() {
+        assertThatThrownBy(() -> PathSecurity.resolveContained(baseDir, "valid/../../escape"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void resolveContained_absoluteEscape_isRejected() {
+        // An absolute fragment replaces the base entirely when resolved.
+        assertThatThrownBy(() -> PathSecurity.resolveContained(baseDir, "/etc/shadow"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void resolveContained_nullChild_isRejected() {
+        assertThatThrownBy(() -> PathSecurity.resolveContained(baseDir, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null or blank");
+    }
+
+    @Test
+    public void resolveContained_blankChild_isRejected() {
+        assertThatThrownBy(() -> PathSecurity.resolveContained(baseDir, "   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null or blank");
+    }
+
+    @Test
+    public void isContained_baseItself_isTrue() {
+        assertThat(PathSecurity.isContained(baseDir, baseDir)).isTrue();
+    }
+
+    @Test
+    public void isContained_siblingDirectory_isFalse() {
+        Path sibling = Paths.get("/var/jahia/imports").toAbsolutePath().normalize();
+        assertThat(PathSecurity.isContained(baseDir, sibling)).isFalse();
+    }
+
+    @Test
+    public void isContained_prefixCollisionSibling_isFalse() {
+        // /var/jahia/exports-other must NOT be considered inside /var/jahia/exports
+        Path tricky = Paths.get("/var/jahia/exports-other/file").toAbsolutePath().normalize();
+        assertThat(PathSecurity.isContained(baseDir, tricky)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving hardening of the website import/export GraphQL mutations. The export path containment from the prior fix is retained; this PR closes residual traversal and null-safety gaps and extracts the containment logic into a unit-tested helper.

## Changes

- **S1/R1 — importWebsite siteKey traversal** (`WebsitesMutation`): the untrusted GraphQL `siteKey` was used directly as a directory name (`Paths.get(absoluteImportPath, siteKey)`); only `importPath` was containment-checked. A `siteKey` such as `../../x` could escape `jahiaImportsDiskPath`. Both `importPath` and `siteKey` are now validated via `PathSecurity.resolveContained`.
- **S2/R2 — exportWebsite null site NPE**: `getSiteByKey(siteKey)` could return null and was cast/added to the export list, causing an NPE inside `exportSites` (swallowed by the broad catch). Now returns `false` early with a clear log. The `ByteArrayOutputStream` sink is closed via try-with-resources.
- **S3/R3 — importFiles null systemsite NPE**: `system.getSiteKey()` was dereferenced without a null check; a missing system site caused an NPE. Now logs and returns.
- **S4/R4 — magic numbers**: S3 throughput (`20.0` Gbps) and part size (`8 * MB`) extracted into named constants.
- **PathSecurity** (new): pure, testable containment helper shared by both mutations.

## Tests

- `PathSecurityTest` — 10 JUnit 4 tests (traversal, absolute escape, nested child, prefix-collision sibling, null/blank rejection). JUnit 4 used deliberately because the `jahia-modules` parent pins the `surefire-junit4` provider (Jupiter would silently report 0).
- `mvn clean install`: **BUILD SUCCESS**, Tests run: **10**, Failures: 0, Errors: 0.

## Behavior preservation

The E2E happy path is unaffected: `exportPath='cypress-export'` and `siteKey='systemsite'` both resolve as contained. All mutations remain `@GraphQLRequiresPermission("admin")` — permission gating untouched.

## Notes

No Docker/Cypress run (out of scope). CLA may apply.