### PR TITLE
feat: add websitesAdmin permission for fine-grained RBAC

### DIFF
--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <websitesAdmin jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
@@ -70,7 +70,7 @@ public class WebsitesMutation {
 
     @GraphQLField
     @GraphQLDescription("Create a website")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("websitesAdmin")
     public static Boolean createSiteByKey(
             @GraphQLName("siteKey") @GraphQLDescription("Site key") String siteKey,
             @GraphQLName("serverName") @GraphQLDescription("Server name") String serverName,
@@ -109,7 +109,7 @@ public class WebsitesMutation {
 
     @GraphQLField
     @GraphQLDescription("Delete a website")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("websitesAdmin")
     public static Boolean deleteSiteByKey(
             @GraphQLName("siteKey") @GraphQLDescription("Site key") String siteKey
     ) {
@@ -132,7 +132,7 @@ public class WebsitesMutation {
     @GraphQLField
     @GraphQLDescription("Export a website")
     @GraphQLAsync
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("websitesAdmin")
     public static Boolean exportWebsite(
             @GraphQLName("siteKey") @GraphQLDescription("Site key") String siteKey,
             @GraphQLName("exportPath") @GraphQLDescription("Export path") String exportPath,
@@ -191,7 +191,7 @@ public class WebsitesMutation {
 
     @GraphQLField
     @GraphQLDescription("Import a website")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("websitesAdmin")
     public static Boolean importWebsite(@GraphQLName("importPath") @GraphQLDescription("Import path") String importPath,
                                         @GraphQLName("siteKey") @GraphQLDescription("Site key") String siteKey) throws IOException {
         LOGGER.info("Processing Import");
@@ -372,7 +372,7 @@ public class WebsitesMutation {
 
     @GraphQLField
     @GraphQLDescription("Export All Sites towards the configured S3 bucket")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("websitesAdmin")
     public static ExportAllSitesResults exportAllSites() {
         GraphQLWebsitesConfig websitesConfig = BundleUtils.getOsgiService(GraphQLWebsitesConfig.class, null);
         SettingsBean settingsBean = BundleUtils.getOsgiService(SettingsBean.class, null);


### PR DESCRIPTION
## Summary

- Adds `src/main/import/permissions.xml` defining a `websitesAdmin` JCR permission as a child of `admin` (Jahia Maven plugin auto-packages it into `import.zip`)
- Replaces all 5 `@GraphQLRequiresPermission("admin")` annotations in `WebsitesMutation` with `@GraphQLRequiresPermission("websitesAdmin")`
- Full admins retain access via JCR privilege inheritance — no behaviour change for existing admin users

## Files changed

| File | Change |
|------|--------|
| `src/main/import/permissions.xml` | New — declares `websitesAdmin` child permission under `admin` |
| `src/main/java/.../WebsitesMutation.java` | 5 annotations updated from `"admin"` to `"websitesAdmin"` |

## Test plan

- [ ] `mvn clean install` passes (verified locally — green)
- [ ] Deploy module to a Jahia instance and confirm a full admin can still invoke all mutations
- [ ] Grant only `websitesAdmin` to a non-admin user and confirm they can invoke the mutations
- [ ] Confirm a user with neither `admin` nor `websitesAdmin` receives a permission-denied error