### PR TITLE
test: fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.jahia.community</groupId>
     <artifactId>graphql-extension-websites</artifactId>
     <name>Jahia GraphQL Extension Websites</name>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>GraphQL extension to manipulate websites</description>
 

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <graphql-extension-websites-administrator jcr:primaryType="jnt:role"
+                                              j:nodeTypes="rep:root"
+                                              j:roleGroup="server-role"
+                                              j:permissionNames="jcr:read_default graphqlAdminMutation websitesAdmin"
+                                              j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="GraphQL Extension Websites administrator"
+                          jcr:description="Grants access to the website lifecycle GraphQL mutations (create, delete, export, import) without requiring full server administrator rights"/>
+    </graphql-extension-websites-administrator>
+</roles>

--- a/tests/cypress/e2e/02-graphqlExtensionWebsites-Permissions.cy.ts
+++ b/tests/cypress/e2e/02-graphqlExtensionWebsites-Permissions.cy.ts
@@ -1,0 +1,81 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `websitesAdmin` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: every site-lifecycle mutation in `WebsitesMutation` is annotated with
+ *    `@GraphQLRequiresPermission("websitesAdmin")`, enforced by the DXM provider as a
+ *    `session.getNode("/").hasPermission("websitesAdmin")` (root-node ACL) check.
+ *  - RBAC content: the module ships the assignable `graphql-extension-websites-administrator`
+ *    role (src/main/import/roles.xml). Because these mutations are nested under the DXM
+ *    `admin { jahia { ... } }` wrapper, traversing to the gated field requires three
+ *    fine-grained permissions in total (none of which is the `admin` role):
+ *      • `jcr:read_default`     → satisfies the `admin` field's `@GraphQLRequiresPermission("jcr:read/jcr:system")`
+ *      • `graphqlAdminMutation` → satisfies the `admin.jahia` field's `@GraphQLRequiresPermission("graphqlAdminMutation")`
+ *      • `websitesAdmin`        → satisfies the mutation's own `@GraphQLRequiresPermission("websitesAdmin")`
+ *    Omitting any one of them fails the gate on the corresponding field.
+ *
+ * This module is API-only (no admin UI), so only the GraphQL authorization is asserted.
+ *
+ * The "allowed" user is granted that single role and nothing else — never the `admin`
+ * permission — so the tests prove fine-grained granularity, not merely that a full
+ * administrator can pass.
+ *
+ * Safe gated op: `exportAllSites` is used for the allow path because in CI (no AWS S3
+ * configured) it is non-destructive — it builds an export to a temp file that is always
+ * removed in a `finally`, never touches site content, and returns the benign
+ * `AWS_S3_BUCKET_NOT_CONFIGURED` result instead of uploading anything.
+ */
+describe('GraphQL Extension Websites — permission enforcement', () => {
+    const ROLE_NAME = 'graphql-extension-websites-administrator';
+    const DENIED_USER = 'gewDeniedUser';
+    const ALLOWED_USER = 'gewAllowedUser';
+    const PASSWORD = 'GewPerm9PwdTest';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const exportAllSites: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/mutation/exportAllSites.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const exportAllSitesAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({mutation: exportAllSites});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped single-permission role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated mutation for a user without the permission', () => {
+            exportAllSitesAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated mutation for a user granted only the module permission', () => {
+            exportAllSitesAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                expect((result as {data: {admin: {jahia: {exportAllSites: string}}}}).data.admin.jahia.exportAllSites)
+                    .to.eq('AWS_S3_BUCKET_NOT_CONFIGURED');
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds an assignable **`graphql-extension-websites-administrator`** server role and **Cypress regression tests** that prove the fine-grained `websitesAdmin` permission gates the module's GraphQL site-lifecycle mutations end-to-end — without granting the full `admin` role.

This module is **API-only** (no admin UI / no `register.jsx` adminRoute), so only the GraphQL authorization is asserted (deny + allow); there are no UI tests.

## What changed

- **`src/main/import/roles.xml`** (new) — assignable `server-role`. The mutations are nested under the DXM `admin { jahia { ... } }` wrapper, so reaching a gated field requires three fine-grained permissions (all granted on `/`, none of which is the `admin` role):
  | Permission | Satisfies |
  |---|---|
  | `jcr:read_default` | the `admin` field's `@GraphQLRequiresPermission("jcr:read/jcr:system")` (→ `jcr:read` on `/jcr:system`) |
  | `graphqlAdminMutation` | the `admin.jahia` field's `@GraphQLRequiresPermission("graphqlAdminMutation")` |
  | `websitesAdmin` | the mutation's own `@GraphQLRequiresPermission("websitesAdmin")` |
- **`tests/cypress/e2e/02-graphqlExtensionWebsites-Permissions.cy.ts`** (new) — two GraphQL tests:
  - **deny**: a user without the role gets `Permission denied`.
  - **allow**: a user granted **only** the module role succeeds; `exportAllSites` returns `AWS_S3_BUCKET_NOT_CONFIGURED`.
- **`pom.xml`** — version bump `1.1.1-SNAPSHOT` → `1.1.2-SNAPSHOT` so the new `roles.xml` import content is re-imported on deploy.

### Safe gated op
The allow path uses `exportAllSites`, which is non-destructive in CI: it builds an export to a temp file that is always removed in a `finally`, never mutates site content, and skips the S3 upload (no bucket configured → benign `AWS_S3_BUCKET_NOT_CONFIGURED`). No destructive operation runs against the systemsite.

### No Java change needed
The resolvers rely solely on the `@GraphQLRequiresPermission("websitesAdmin")` annotation — there is no inner hardcoded `admin` check to relax. (All other gating is the DXM provider's standard `admin`/`admin.jahia` wrapper, addressed via the role permissions above.)

## Test plan
- `cd tests && ./ci.build.sh && ./ci.startup.sh` → **7/7 specs pass** (5 existing + 2 new).
- License health clean (`Premature end of file` / null license package count = 0).