### PR TITLE
Harden graphql-extension-websites: PathSecurity, error handling, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,45 @@
 
 The purpose of this module is to allow the creation, deletion, import and export of a website thanks to GraphQL queries.
 
+## Permissions
+
+**All mutations in this module require the `websitesAdmin` permission.**  Callers that do not
+hold this permission will have their request rejected by the GraphQL security layer before
+any operation is attempted.
+
+Note that `exportAllSites` temporarily escalates the JCR session to the root user so that
+the full instance content (all sites, roles, users) is exported, regardless of what the
+calling user can normally read.  Grant `websitesAdmin` only to fully trusted administrators.
+
 ## Installation
 
 - In Jahia, go to "Administration --> Server settings --> System components --> Modules"
 - Upload the JAR **graphql-extension-websites-X.X.X.jar**
 - Check that the module is started
+
+## Configuration (AWS S3 for exportAllSites)
+
+AWS S3 credentials and bucket details **must** be set via the OSGi ConfigurationAdmin
+service — never pass them inline in a GraphQL mutation.
+
+Edit (or drop) the file at:
+
+```
+<jahia-var>/karaf/etc/org.jahia.community.graphql.websites.cfg
+```
+
+```properties
+aws.s3.region=us-east-1
+aws.s3.bucketName=my-backup-bucket
+aws.s3.accessKey=<your-access-key-id>
+aws.s3.secretAccessKey=<your-secret-access-key>
+```
+
+The default shipped configuration (`src/main/resources/META-INF/configurations/org.jahia.community.graphql.websites.cfg`)
+has all values blank so that `exportAllSites` returns `AWS_S3_BUCKET_NOT_CONFIGURED` until
+the administrator provides real credentials.  Jahia's module extender will **not** overwrite
+a deployed `karaf/etc` file that was already customised (the file starts with
+`# default configuration - won't be overridden`).
 
 ## How to use
 ### In the tools
@@ -68,22 +102,10 @@ mutation {
 ```
 
 #### Export All Sites To AWS S3
-- Configure your S3 endpoint in the Jahia configuration file
-```graphql
-mutation {
-    admin {
-        jahia {
-            configuration( pid: "org.jahia.community.graphql.websites" ) {
-                awsRegion: value(name:"aws.s3.region", value:"us-east-2"),
-                awsBucketName: value(name:"aws.s3.bucketName", value:"graphqltestbucketonaws"),
-                awsAccessKey: value(name:"aws.s3.accessKey", value:"test")
-                awsSecretAccessKey: value(name:"aws.s3.secretAccessKey", value:"test")
-            }
-        }
-    }
-}
-```
-- Then launch the export of all sites
+
+Configure credentials via the `.cfg` file described in the **Configuration** section above,
+then trigger the export:
+
 ```graphql
 mutation {
     admin {
@@ -93,3 +115,21 @@ mutation {
     }
 }
 ```
+
+Possible return values:
+- `SUCCESS` — export and S3 upload completed; the local ZIP was removed.
+- `AWS_S3_BUCKET_NOT_CONFIGURED` — one or more S3 config values are blank; no upload attempted.
+- `FAILURE` — unexpected error (check the Jahia server logs).
+
+> **Security note:** do **not** set credentials inline via the `configuration(...)` mutation
+> as shown in older documentation.  That approach leaks secrets into GraphQL access logs and
+> audit trails.  Use the `.cfg` file or an OSGi-compatible secrets manager instead.
+
+## Residual risks (documented, not fixed here)
+
+- **Pre-import zip-slip / archive validation**: the ZIP content is validated by Jahia core's
+  `ImportExportBaseService`.  This module delegates entirely to that layer; no additional
+  ZIP-slip check is performed here.  The mutation is gated by `websitesAdmin`, so only
+  trusted administrators can trigger imports.
+- **`exportAllSites` privilege scope**: as noted above, the export runs as root and captures
+  the whole instance.  Re-scoping to a stronger permission than `websitesAdmin` is deferred.

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/GraphQLWebsitesConfig.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/GraphQLWebsitesConfig.java
@@ -7,10 +7,7 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Dictionary;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component(service = {ManagedService.class, GraphQLWebsitesConfig.class}, property = {
         "service.pid=org.jahia.community.graphql.websites",
@@ -25,48 +22,79 @@ public class GraphQLWebsitesConfig implements ManagedService {
     static final String AWS_S3_ACCESS_KEY = "aws.s3.accessKey";
     static final String AWS_S3_SECRET_ACCESS_KEY = "aws.s3.secretAccessKey";
 
-    // Initialized to an empty map so getConfig()/getAwsS3*() are safe before updated() is called
-    private volatile Map<String, String> config = Collections.emptyMap();
-    private volatile boolean isConfigured;
+    /**
+     * Immutable snapshot of resolved configuration values.
+     * Published via a single volatile field so reads are atomic — either the caller
+     * sees the old complete snapshot or the new complete snapshot, never a mix.
+     */
+    private static final class ConfigSnapshot {
+        final String awsS3Region;
+        final String awsS3BucketName;
+        final String awsS3AccessKey;
+        final String awsS3SecretAccessKey;
+        final boolean configured;
+
+        ConfigSnapshot(String region, String bucket, String accessKey, String secretKey) {
+            this.awsS3Region = region;
+            this.awsS3BucketName = bucket;
+            this.awsS3AccessKey = accessKey;
+            this.awsS3SecretAccessKey = secretKey;
+            this.configured = !StringUtils.isBlank(region)
+                    && !StringUtils.isBlank(bucket)
+                    && !StringUtils.isBlank(accessKey)
+                    && !StringUtils.isBlank(secretKey);
+        }
+
+        /** Empty, not-configured snapshot used before the first updated() call. */
+        static final ConfigSnapshot EMPTY = new ConfigSnapshot(null, null, null, null);
+    }
+
+    // Single volatile reference; replaced atomically on each updated() call.
+    private volatile ConfigSnapshot snapshot = ConfigSnapshot.EMPTY;
 
     @Override
     public void updated(Dictionary<String, ?> dictionary) throws ConfigurationException {
-        if (dictionary != null && !dictionary.isEmpty()) {
-            // Do something with the configuration
-            final Map<String, String> newConfig = new HashMap<>(4);
-            dictionary.keys().asIterator().forEachRemaining(key -> {
-                LOGGER.info("Configuration key: {}", key);
-                String value = (String) dictionary.get(key);
-                if (!StringUtils.isEmpty(value)) {
-                    newConfig.put(key, value);
-                }
-            });
-            config = Collections.unmodifiableMap(newConfig);
-            isConfigured = config.containsKey(AWS_S3_REGION) && config.containsKey(AWS_S3_BUCKET_NAME) && config.containsKey(AWS_S3_ACCESS_KEY) && config.containsKey(AWS_S3_SECRET_ACCESS_KEY);
+        if (dictionary == null) {
+            // OSGi may call updated(null) to signal configuration deletion.
+            snapshot = ConfigSnapshot.EMPTY;
+            return;
         }
+        final String region     = extract(dictionary, AWS_S3_REGION);
+        final String bucket     = extract(dictionary, AWS_S3_BUCKET_NAME);
+        final String accessKey  = extract(dictionary, AWS_S3_ACCESS_KEY);
+        final String secretKey  = extract(dictionary, AWS_S3_SECRET_ACCESS_KEY);
+
+        snapshot = new ConfigSnapshot(region, bucket, accessKey, secretKey);
+        LOGGER.info("GraphQLWebsitesConfig updated; configured={}", snapshot.configured);
     }
 
-    public Map<String, String> getConfig() {
-        return config;
+    /** Returns the non-blank value for {@code key}, or {@code null} if absent or blank. */
+    private static String extract(Dictionary<String, ?> dict, String key) {
+        Object raw = dict.get(key);
+        if (raw == null) {
+            return null;
+        }
+        String value = raw.toString();
+        return StringUtils.isBlank(value) ? null : value;
     }
 
     public String getAwsS3Region() {
-        return config.get(AWS_S3_REGION);
+        return snapshot.awsS3Region;
     }
 
     public String getAwsS3AccessKey() {
-        return config.get(AWS_S3_ACCESS_KEY);
+        return snapshot.awsS3AccessKey;
     }
 
     public String getAwsS3BucketName() {
-        return config.get(AWS_S3_BUCKET_NAME);
+        return snapshot.awsS3BucketName;
     }
 
     public String getAwsS3SecretAccessKey() {
-        return config.get(AWS_S3_SECRET_ACCESS_KEY);
+        return snapshot.awsS3SecretAccessKey;
     }
 
     public boolean isConfigured() {
-        return isConfigured;
+        return snapshot.configured;
     }
 }

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/GraphQLWebsitesConfig.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/GraphQLWebsitesConfig.java
@@ -49,7 +49,10 @@ public class GraphQLWebsitesConfig implements ManagedService {
         static final ConfigSnapshot EMPTY = new ConfigSnapshot(null, null, null, null);
     }
 
-    // Single volatile reference; replaced atomically on each updated() call.
+    // Single volatile reference to an IMMUTABLE snapshot, replaced atomically on each
+    // updated() call. Safe publication via a volatile reference to an immutable object is
+    // the correct idiom, so S3077 ("volatile is not enough") is a false positive here.
+    @SuppressWarnings("java:S3077")
     private volatile ConfigSnapshot snapshot = ConfigSnapshot.EMPTY;
 
     @Override

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/ImportInfo.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/ImportInfo.java
@@ -15,6 +15,8 @@ import org.slf4j.LoggerFactory;
 
 public class ImportInfo implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ImportInfo.class);
     private Boolean defaultSite;
     private Boolean mixLanguage;

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurity.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurity.java
@@ -1,14 +1,30 @@
 package org.jahia.community.graphql.provider.dxm.extensions.websites;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
  * Path containment helpers shared by the website export/import mutations.
  *
  * <p>All user-supplied path fragments coming from GraphQL input (export path, import path,
- * site key) are untrusted and may contain {@code ..} segments or absolute escapes. These
- * helpers resolve a child against a trusted base directory and verify that the canonical
- * result stays inside that base, rejecting any traversal attempt.
+ * site key) are untrusted and may contain {@code ..} segments, absolute escapes, or null
+ * bytes. These helpers resolve a child against a trusted base directory and verify that the
+ * canonical result stays inside that base, rejecting any traversal attempt.
+ *
+ * <h3>Two-layer containment check</h3>
+ * <ol>
+ *   <li><b>Lexical check</b> – {@link Path#normalize()} removes {@code ..} segments and is
+ *       fast, but does <em>not</em> resolve symbolic links.</li>
+ *   <li><b>Real-path check</b> – resolves the real filesystem path of the deepest existing
+ *       ancestor of the candidate (walking up until a path component actually exists on
+ *       disk), then verifies that real path still starts with the real base. This catches
+ *       symlinks placed inside the base directory that point outside it. Export paths may
+ *       not yet exist (they will be created by the export), so we canonicalize the nearest
+ *       existing ancestor rather than the full path. The real-path layer is only applied
+ *       when the base directory itself exists on disk; if it does not exist the lexical
+ *       check alone is used (unit-test / early-startup scenario).</li>
+ * </ol>
  */
 final class PathSecurity {
 
@@ -18,27 +34,77 @@ final class PathSecurity {
 
     /**
      * Resolves {@code child} against {@code baseDir} and verifies the normalized result is
-     * contained within {@code baseDir}.
+     * contained within {@code baseDir}, using both a lexical check and (when the base
+     * exists on disk) a real-path symlink-aware check.
      *
      * @param baseDir trusted, already-normalized absolute base directory
      * @param child   untrusted relative fragment from external input (may be {@code null})
      * @return the normalized, contained absolute path
-     * @throws IllegalArgumentException if {@code child} is null/blank or escapes {@code baseDir}
+     * @throws IllegalArgumentException if {@code child} is null/blank, contains a null byte,
+     *                                  or escapes {@code baseDir}
      */
     static Path resolveContained(Path baseDir, String child) {
         if (child == null || child.trim().isEmpty()) {
             throw new IllegalArgumentException("Path fragment must not be null or blank");
         }
+        // Reject null bytes (C-string truncation attack on some JVM/OS combos)
+        if (child.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException("Path fragment must not contain null bytes");
+        }
         final Path resolved = baseDir.resolve(child).normalize();
+
+        // Layer 1: lexical containment check
         if (!isContained(baseDir, resolved)) {
             throw new IllegalArgumentException(
                     "Path fragment '" + child + "' resolves outside the allowed directory");
         }
+
+        // Layer 2: real-path (symlink-aware) check.
+        // Only applied when the base directory actually exists on disk; skipped otherwise
+        // (e.g. in unit tests using non-existent paths like /var/jahia/exports).
+        if (Files.exists(baseDir)) {
+            try {
+                final Path realBase = baseDir.toRealPath();
+                final Path realAncestor = toRealPathOfExistingAncestor(resolved);
+                if (!realAncestor.startsWith(realBase)) {
+                    throw new IllegalArgumentException(
+                            "Path fragment '" + child + "' resolves outside the allowed directory (symlink escape detected)");
+                }
+            } catch (IOException ex) {
+                // If we cannot canonicalize, fail closed.
+                throw new IllegalArgumentException(
+                        "Cannot verify path containment for '" + child + "': " + ex.getMessage());
+            }
+        }
+
         return resolved;
     }
 
     /**
-     * @return {@code true} when {@code candidate} is {@code baseDir} itself or a descendant of it.
+     * Walks up from {@code path} until it finds a component that actually exists on disk,
+     * then returns {@link Path#toRealPath()} of that ancestor. This allows validation of
+     * paths that do not yet exist (e.g. an export file about to be created).
+     *
+     * <p>If no ancestor exists at all (not even the filesystem root), returns
+     * {@link Path#toAbsolutePath()} of {@code path} to avoid an infinite loop.
+     *
+     * @throws IOException if {@code toRealPath()} fails for an existing path
+     */
+    static Path toRealPathOfExistingAncestor(Path path) throws IOException {
+        Path candidate = path.toAbsolutePath().normalize();
+        while (candidate != null) {
+            if (Files.exists(candidate)) {
+                return candidate.toRealPath();
+            }
+            candidate = candidate.getParent();
+        }
+        // Fallback: path has no existing ancestor at all — return as-is.
+        return path.toAbsolutePath().normalize();
+    }
+
+    /**
+     * @return {@code true} when {@code candidate} is {@code baseDir} itself or a descendant
+     *         of it (lexical check only — does not resolve symlinks).
      */
     static boolean isContained(Path baseDir, Path candidate) {
         final Path normalizedBase = baseDir.normalize();

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
@@ -172,6 +172,20 @@ public class WebsitesMutation {
      */
     @GraphQLField
     @GraphQLDescription("Export a website")
+    /**
+     * Resolves a user-supplied path against a base directory using {@link PathSecurity},
+     * returning {@code null} (and logging) instead of propagating {@link IllegalArgumentException}
+     * when the path is rejected. Extracted to avoid a nested try block (Sonar S1141).
+     */
+    private static Path resolveContainedOrNull(Path baseDir, String candidate, String operation) {
+        try {
+            return PathSecurity.resolveContained(baseDir, candidate);
+        } catch (IllegalArgumentException ex) {
+            LOGGER.error("{}: rejected path '{}': {}", operation, candidate, ex.getMessage());
+            return null;
+        }
+    }
+
     @GraphQLAsync
     @GraphQLRequiresPermission("websitesAdmin")
     public static Boolean exportWebsite(
@@ -182,11 +196,8 @@ public class WebsitesMutation {
         try {
             final SettingsBean settingsBean = BundleUtils.getOsgiService(SettingsBean.class, null);
             final Path exportsBaseDir = Paths.get(settingsBean.getJahiaVarDiskPath(), "exports").toAbsolutePath().normalize();
-            final Path resolvedExportPath;
-            try {
-                resolvedExportPath = PathSecurity.resolveContained(exportsBaseDir, exportPath);
-            } catch (IllegalArgumentException ex) {
-                LOGGER.error("exportWebsite: rejected exportPath '{}': {}", exportPath, ex.getMessage());
+            final Path resolvedExportPath = resolveContainedOrNull(exportsBaseDir, exportPath, "exportWebsite");
+            if (resolvedExportPath == null) {
                 return Boolean.FALSE;
             }
             final JahiaSite site = ServicesRegistry.getInstance().getJahiaSitesService().getSiteByKey(siteKey);
@@ -227,10 +238,12 @@ public class WebsitesMutation {
             final List<JCRSiteNode> siteList = new ArrayList<>();
             siteList.add((JCRSiteNode) site);
             final ImportExportBaseService importExportBaseService = ServicesRegistry.getInstance().getImportExportService();
-            // Fix E: the real output goes via SERVER_DIRECTORY in params; a ByteArrayOutputStream
-            // would buffer the entire export in memory causing OOM on large sites.
-            // Use a null sink since the API requires a non-null OutputStream argument.
-            importExportBaseService.exportSites(OutputStream.nullOutputStream(), params, siteList);
+            // The export content is produced via SERVER_DIRECTORY in params; the OutputStream
+            // argument is required by the API. Use a try-with-resources stream sink (matching
+            // the proven upstream behavior) rather than discarding it.
+            try (ByteArrayOutputStream exportSink = new ByteArrayOutputStream()) {
+                importExportBaseService.exportSites(exportSink, params, siteList);
+            }
             return Boolean.TRUE;
         } catch (JahiaException | RepositoryException | IOException | SAXException | TransformerException ex) {
             LOGGER.error("Impossible to export website '{}'", siteKey, ex);
@@ -454,8 +467,8 @@ public class WebsitesMutation {
                 }
                 return null;
             });
-        // Fix G: narrow the outer catch to the actually-thrown checked exceptions;
-        // RuntimeException and Error propagate naturally rather than being swallowed.
+        // Only the checked exceptions actually thrown are caught here, so unchecked
+        // RuntimeException and Error propagate instead of being silently swallowed.
         } catch (IOException | RepositoryException e) {
             LOGGER.error("Cannot create site '{}'", infos.getSiteTitle(), e);
             successful = Boolean.FALSE;

--- a/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
+++ b/src/main/java/org/jahia/community/graphql/provider/dxm/extensions/websites/WebsitesMutation.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
 import javax.jcr.RepositoryException;
 import javax.xml.transform.TransformerException;
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
@@ -53,13 +54,28 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
+/**
+ * GraphQL mutation extensions for Jahia website lifecycle operations (create, delete,
+ * export, import, bulk export-to-S3).
+ *
+ * <p><b>Permission:</b> every mutation in this class is gated by the
+ * {@code websitesAdmin} permission via {@link GraphQLRequiresPermission}.  The caller
+ * must hold that permission; unauthenticated or insufficiently privileged requests are
+ * rejected by the GraphQL security layer before the method body executes.
+ *
+ * <p><b>Privilege-scope caveat for {@link #exportAllSites()}:</b> that mutation
+ * temporarily switches the active JCR session to the root user so that all content
+ * (including content the calling user cannot normally read) is included in the export.
+ * It exports the entire Jahia instance.  Callers granted {@code websitesAdmin} should
+ * understand this elevation.  See the README for configuration details.
+ */
 @GraphQLTypeExtension(GqlJahiaAdminMutation.class)
 public class WebsitesMutation {
     private static final String JAHIA_RELEASE = "JahiaRelease";
     private static final Logger LOGGER = LoggerFactory.getLogger(WebsitesMutation.class);
     private static final String ERR_MSG_ERR_WHEN_GETTING_TPL = "Error when getting templates";
-    private static final String ERR_MSG_IMP_TO_CREATE_SITE = "Impossible to create website %s";
-    private static final String ERR_MSG_IMP_TO_DELETE_SITE = "Impossible to delete website %s";
+    private static final String ERR_MSG_IMP_TO_CREATE_SITE = "Impossible to create website '{}'";
+    private static final String ERR_MSG_IMP_TO_DELETE_SITE = "Impossible to delete website '{}'";
     private static final String FILES = "files";
     private static final String SITE = "site";
     private static final String SHARED_FILES = "/shared/files/";
@@ -68,6 +84,12 @@ public class WebsitesMutation {
     private static final double S3_TARGET_THROUGHPUT_GBPS = 20.0;
     private static final long S3_MINIMUM_PART_SIZE_BYTES = 8L * SizeConstant.MB;
 
+    /**
+     * Creates a Jahia website with the supplied parameters.
+     *
+     * @return {@code true} on success; {@code false} if site creation fails (e.g. the
+     *         template set is not installed, or a site with that key already exists)
+     */
     @GraphQLField
     @GraphQLDescription("Create a website")
     @GraphQLRequiresPermission("websitesAdmin")
@@ -96,17 +118,23 @@ public class WebsitesMutation {
                     ServicesRegistry.getInstance().getJahiaSitesService().addSite(siteCreationInfo, session);
                     result = Boolean.TRUE;
                 } catch (IOException | JahiaException ex) {
-                    LOGGER.error(String.format(ERR_MSG_IMP_TO_CREATE_SITE, siteKey), ex);
+                    LOGGER.error(ERR_MSG_IMP_TO_CREATE_SITE, siteKey, ex);
                     result = Boolean.FALSE;
                 }
                 return result;
             });
         } catch (RepositoryException ex) {
-            LOGGER.error(String.format(ERR_MSG_IMP_TO_CREATE_SITE, siteKey), ex);
+            LOGGER.error(ERR_MSG_IMP_TO_CREATE_SITE, siteKey, ex);
         }
         return Boolean.FALSE;
     }
 
+    /**
+     * Deletes the Jahia website identified by {@code siteKey}.
+     *
+     * @return {@code true} on success; {@code false} if the site was not found or deletion
+     *         fails
+     */
     @GraphQLField
     @GraphQLDescription("Delete a website")
     @GraphQLRequiresPermission("websitesAdmin")
@@ -118,17 +146,30 @@ public class WebsitesMutation {
             final JahiaSitesService jahiaSitesServices = ServicesRegistry.getInstance().getJahiaSitesService();
             final JahiaSite jahiaSite = jahiaSitesServices.getSiteByKey(siteKey);
             if (jahiaSite == null) {
-                LOGGER.error(String.format(ERR_MSG_IMP_TO_DELETE_SITE + ": site not found", siteKey));
+                // Fix A: SLF4J parameterized logging — no String.format, no concatenation
+                LOGGER.error("Impossible to delete website '{}': site not found", siteKey);
                 return Boolean.FALSE;
             }
             jahiaSitesServices.removeSite(jahiaSite);
             success = Boolean.TRUE;
         } catch (JahiaException | RuntimeException ex) {
-            LOGGER.error(String.format(ERR_MSG_IMP_TO_DELETE_SITE, siteKey), ex);
+            LOGGER.error(ERR_MSG_IMP_TO_DELETE_SITE, siteKey, ex);
         }
         return success;
     }
 
+    /**
+     * Exports a single website to an on-disk directory.
+     *
+     * <p>This mutation is {@link GraphQLAsync}: the GraphQL response is returned before the
+     * export completes.  Clients cannot poll for completion via this mutation.
+     *
+     * @param siteKey      key of the site to export
+     * @param exportPath   path relative to {@code jahiaVarDiskPath/exports/}; must not
+     *                     escape that directory
+     * @param onlyStaging  when {@code true} only staging content is included
+     * @return {@code true} on success; {@code false} on error or invalid path
+     */
     @GraphQLField
     @GraphQLDescription("Export a website")
     @GraphQLAsync
@@ -151,6 +192,13 @@ public class WebsitesMutation {
             final JahiaSite site = ServicesRegistry.getInstance().getJahiaSitesService().getSiteByKey(siteKey);
             if (site == null) {
                 LOGGER.error("exportWebsite: site '{}' not found", siteKey);
+                return Boolean.FALSE;
+            }
+            // Refuse to delete if the resolved path is a symlink — a symlink at the
+            // export location could redirect deletion to an arbitrary target outside the
+            // exports directory (Fix J continuation).
+            if (Files.isSymbolicLink(resolvedExportPath)) {
+                LOGGER.error("exportWebsite: refused to delete '{}': path is a symbolic link", resolvedExportPath);
                 return Boolean.FALSE;
             }
             // Jahia rejects a server export directory that already contains files
@@ -179,21 +227,34 @@ public class WebsitesMutation {
             final List<JCRSiteNode> siteList = new ArrayList<>();
             siteList.add((JCRSiteNode) site);
             final ImportExportBaseService importExportBaseService = ServicesRegistry.getInstance().getImportExportService();
-            try (ByteArrayOutputStream exportSink = new ByteArrayOutputStream()) {
-                importExportBaseService.exportSites(exportSink, params, siteList);
-            }
+            // Fix E: the real output goes via SERVER_DIRECTORY in params; a ByteArrayOutputStream
+            // would buffer the entire export in memory causing OOM on large sites.
+            // Use a null sink since the API requires a non-null OutputStream argument.
+            importExportBaseService.exportSites(OutputStream.nullOutputStream(), params, siteList);
             return Boolean.TRUE;
         } catch (JahiaException | RepositoryException | IOException | SAXException | TransformerException ex) {
-            LOGGER.error(String.format("Impossible to export website %s", siteKey), ex);
+            LOGGER.error("Impossible to export website '{}'", siteKey, ex);
         }
         return Boolean.FALSE;
     }
 
+    /**
+     * Imports a website from a prepared directory on disk.
+     *
+     * <p>The directory at {@code importPath} (relative to {@code jahiaImportsDiskPath})
+     * must contain {@code export.properties}, {@code roles/}, {@code users/}, and a
+     * sub-directory named after {@code siteKey}.
+     *
+     * @param importPath path relative to {@code jahiaImportsDiskPath}
+     * @param siteKey    target site key; also used as a directory name under importPath
+     * @return {@code true} on success; {@code false} on error or invalid path
+     */
     @GraphQLField
     @GraphQLDescription("Import a website")
     @GraphQLRequiresPermission("websitesAdmin")
+    // Fix F: removed dead `throws IOException` — the IOException is caught internally
     public static Boolean importWebsite(@GraphQLName("importPath") @GraphQLDescription("Import path") String importPath,
-                                        @GraphQLName("siteKey") @GraphQLDescription("Site key") String siteKey) throws IOException {
+                                        @GraphQLName("siteKey") @GraphQLDescription("Site key") String siteKey) {
         LOGGER.info("Processing Import");
         Boolean successful = Boolean.TRUE;
         final Path importsBaseDir = Paths.get(BundleUtils.getOsgiService(SettingsBean.class, null).getJahiaImportsDiskPath()).toAbsolutePath().normalize();
@@ -249,8 +310,11 @@ public class WebsitesMutation {
                 if (infos.isSelected()) {
                     String type = infos.getType();
                     if (type.equals(FILES)) {
-                        anythingImported = true;
-                        importFiles(importExportBaseService, jahiaSitesService, importsInfos, infos);
+                        // Fix H: only mark imported when importFiles reports success
+                        boolean fileImported = importFiles(importExportBaseService, jahiaSitesService, importsInfos, infos);
+                        if (fileImported) {
+                            anythingImported = true;
+                        }
                     } else if (type.equals(SITE)) {
                         // site import
                         anythingImported = true;
@@ -285,44 +349,72 @@ public class WebsitesMutation {
         }
     }
 
-    private static void importFiles(ImportExportBaseService importExportBaseService, JahiaSitesService jahiaSitesService, List<ImportInfo> importsInfos, ImportInfo infos) {
+    /**
+     * Imports files (roles zip) for the given {@link ImportInfo} entry.
+     *
+     * <p>Fix B: the nested {@code try} block that was previously inlined inside
+     * {@link #importWebsite} has been extracted here to resolve SonarQube S1141.
+     *
+     * <p>Fix H: returns {@code true} when the import completed without error so the
+     * caller only counts a genuinely successful import.
+     *
+     * @return {@code true} if the import succeeded; {@code false} on any error
+     */
+    private static boolean importFiles(ImportExportBaseService importExportBaseService, JahiaSitesService jahiaSitesService, List<ImportInfo> importsInfos, ImportInfo infos) {
         try {
-            final File file = ImportUpdateService.getInstance().updateImport( // NOSONAR java:S5738
-                    infos.getImportFile(),
-                    infos.getImportFileName(),
-                    infos.getType(),
-                    new Version(infos.getOriginatingJahiaRelease()));
-            final JahiaSite system = jahiaSitesService.getSiteByKey(JahiaSitesService.SYSTEM_SITE_KEY);
-            if (system == null) {
-                LOGGER.error("Cannot import files: system site '{}' not found", JahiaSitesService.SYSTEM_SITE_KEY);
-                return;
-            }
-
-            final Map<String, String> pathMapping = JCRSessionFactory.getInstance()
-                    .getCurrentUserSession().getPathMapping();
-            pathMapping.put(SHARED_FILES, SITES_PATH_PREFIX + system.getSiteKey() + "/files/");
-            pathMapping.put(SHARED_MASHUPS, SITES_PATH_PREFIX + system.getSiteKey() + "/portlets/");
-            importsInfos.stream().filter(infos2 -> (infos2.getOldSiteKey() != null && infos2.getSiteKey() != null && !infos2.getOldSiteKey().equals(infos2.getSiteKey()))).forEachOrdered((ImportInfo infos2)
-                    -> pathMapping.put(SITES_PATH_PREFIX + infos2.getOldSiteKey(), SITES_PATH_PREFIX + infos2.getSiteKey())
-            );
-
-            JCRTemplate.getInstance().doExecuteWithSystemSession((JCRSessionWrapper session) -> {
-                try {
-                    session.getPathMapping().putAll(pathMapping);
-                    importExportBaseService.importSiteZip(file == null ? null : new FileSystemResource(file),
-                            system,
-                            infos.asMap(),
-                            null,
-                            null,
-                            session);
-                } catch (IOException | RepositoryException ex) {
-                    LOGGER.error(ERR_MSG_ERR_WHEN_GETTING_TPL, ex);
-                }
-                return null;
-            });
+            return doImportFiles(importExportBaseService, jahiaSitesService, importsInfos, infos);
         } catch (NumberFormatException | RepositoryException | JahiaException ex) {
             LOGGER.error(ERR_MSG_ERR_WHEN_GETTING_TPL, ex);
+            return false;
         }
+    }
+
+    /**
+     * Inner helper extracted to resolve SonarQube S1141 (nested try).
+     *
+     * @return {@code true} if the import completed without error
+     * @throws RepositoryException propagated from {@link ImportUpdateService} or the JCR call
+     * @throws JahiaException      propagated from site lookup
+     */
+    private static boolean doImportFiles(ImportExportBaseService importExportBaseService, JahiaSitesService jahiaSitesService, List<ImportInfo> importsInfos, ImportInfo infos) throws RepositoryException, JahiaException {
+        final File file = ImportUpdateService.getInstance().updateImport( // NOSONAR java:S5738
+                infos.getImportFile(),
+                infos.getImportFileName(),
+                infos.getType(),
+                new Version(infos.getOriginatingJahiaRelease()));
+        final JahiaSite system = jahiaSitesService.getSiteByKey(JahiaSitesService.SYSTEM_SITE_KEY);
+        if (system == null) {
+            LOGGER.error("Cannot import files: system site '{}' not found", JahiaSitesService.SYSTEM_SITE_KEY);
+            return false;
+        }
+
+        final Map<String, String> pathMapping = JCRSessionFactory.getInstance()
+                .getCurrentUserSession().getPathMapping();
+        pathMapping.put(SHARED_FILES, SITES_PATH_PREFIX + system.getSiteKey() + "/files/");
+        pathMapping.put(SHARED_MASHUPS, SITES_PATH_PREFIX + system.getSiteKey() + "/portlets/");
+        importsInfos.stream()
+                .filter(infos2 -> (infos2.getOldSiteKey() != null && infos2.getSiteKey() != null && !infos2.getOldSiteKey().equals(infos2.getSiteKey())))
+                .forEachOrdered((ImportInfo infos2)
+                        -> pathMapping.put(SITES_PATH_PREFIX + infos2.getOldSiteKey(), SITES_PATH_PREFIX + infos2.getSiteKey())
+                );
+
+        final boolean[] success = {false};
+        JCRTemplate.getInstance().doExecuteWithSystemSession((JCRSessionWrapper session) -> {
+            try {
+                session.getPathMapping().putAll(pathMapping);
+                importExportBaseService.importSiteZip(file == null ? null : new FileSystemResource(file),
+                        system,
+                        infos.asMap(),
+                        null,
+                        null,
+                        session);
+                success[0] = true;
+            } catch (IOException | RepositoryException ex) {
+                LOGGER.error(ERR_MSG_ERR_WHEN_GETTING_TPL, ex);
+            }
+            return null;
+        });
+        return success[0];
     }
 
     private static boolean importSite(JahiaSitesService jahiaSitesService, ImportInfo infos, String absoluteImportPath) {
@@ -362,22 +454,45 @@ public class WebsitesMutation {
                 }
                 return null;
             });
-
-        } catch (Exception e) {
-            LOGGER.error("Cannot create site " + infos.getSiteTitle(), e);
+        // Fix G: narrow the outer catch to the actually-thrown checked exceptions;
+        // RuntimeException and Error propagate naturally rather than being swallowed.
+        } catch (IOException | RepositoryException e) {
+            LOGGER.error("Cannot create site '{}'", infos.getSiteTitle(), e);
             successful = Boolean.FALSE;
         }
         return successful;
     }
 
+    /**
+     * Exports all sites in this Jahia instance to a timestamped ZIP and uploads it to the
+     * configured AWS S3 bucket.
+     *
+     * <p><b>Permission:</b> requires {@code websitesAdmin}.
+     *
+     * <p><b>Privilege escalation:</b> the JCR export runs as the root user so that all
+     * content (including content the calling user cannot read) is included.  The original
+     * user is restored in a {@code finally} block.  This mutation therefore exports the
+     * <em>entire Jahia instance</em>.
+     *
+     * <p><b>S3 credentials:</b> configure AWS credentials via the OSGi ConfigurationAdmin
+     * service (PID {@code org.jahia.community.graphql.websites}) or the
+     * {@code src/main/resources/META-INF/configurations/org.jahia.community.graphql.websites.cfg}
+     * file — <em>never</em> pass credentials inline in the GraphQL mutation.
+     *
+     * @return {@link ExportAllSitesResults#SUCCESS} on success,
+     *         {@link ExportAllSitesResults#AWS_S3_BUCKET_NOT_CONFIGURED} if the S3 bucket
+     *         is not configured, or throws {@link DataFetchingException} on unexpected error
+     */
     @GraphQLField
     @GraphQLDescription("Export All Sites towards the configured S3 bucket")
     @GraphQLRequiresPermission("websitesAdmin")
     public static ExportAllSitesResults exportAllSites() {
         GraphQLWebsitesConfig websitesConfig = BundleUtils.getOsgiService(GraphQLWebsitesConfig.class, null);
         SettingsBean settingsBean = BundleUtils.getOsgiService(SettingsBean.class, null);
-        final Path exportFile = Paths.get(settingsBean.getJahiaVarDiskPath() + File.separator + "exports" + File.separator +
-                "export-" + DateTimeFormatter.ofPattern("yyyyMMddHHmm").format(LocalDateTime.now(ZoneOffset.UTC)) + ".zip");
+        // Fix I: build path with Paths.get + normalize instead of String concatenation with File.separator
+        final String ts = DateTimeFormatter.ofPattern("yyyyMMddHHmm").format(LocalDateTime.now(ZoneOffset.UTC));
+        final Path exportFile = Paths.get(settingsBean.getJahiaVarDiskPath(), "exports", "export-" + ts + ".zip")
+                .toAbsolutePath().normalize();
         try {
             exportAllSites(exportFile);
 

--- a/src/test/java/org/jahia/community/graphql/provider/dxm/extensions/websites/GraphQLWebsitesConfigTest.java
+++ b/src/test/java/org/jahia/community/graphql/provider/dxm/extensions/websites/GraphQLWebsitesConfigTest.java
@@ -1,0 +1,192 @@
+package org.jahia.community.graphql.provider.dxm.extensions.websites;
+
+import org.junit.Test;
+
+import java.util.Hashtable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Unit tests for {@link GraphQLWebsitesConfig}.
+ *
+ * These tests drive the {@code updated()} / getter contract directly without OSGi
+ * container involvement.  Item L of the fix specification.
+ */
+public class GraphQLWebsitesConfigTest {
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private static GraphQLWebsitesConfig freshConfig() {
+        return new GraphQLWebsitesConfig();
+    }
+
+    private static Hashtable<String, Object> allKeys(String region, String bucket, String accessKey, String secretKey) {
+        Hashtable<String, Object> dict = new Hashtable<>();
+        dict.put(GraphQLWebsitesConfig.AWS_S3_REGION, region);
+        dict.put(GraphQLWebsitesConfig.AWS_S3_BUCKET_NAME, bucket);
+        dict.put(GraphQLWebsitesConfig.AWS_S3_ACCESS_KEY, accessKey);
+        dict.put(GraphQLWebsitesConfig.AWS_S3_SECRET_ACCESS_KEY, secretKey);
+        return dict;
+    }
+
+    // -------------------------------------------------------------------------
+    // updated(null) keeps not-configured
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void updated_nullDictionary_remainsNotConfigured() throws Exception {
+        // Arrange
+        GraphQLWebsitesConfig cfg = freshConfig();
+
+        // Act
+        cfg.updated(null);
+
+        // Assert
+        assertThat(cfg.isConfigured()).isFalse();
+        assertThat(cfg.getAwsS3Region()).isNull();
+        assertThat(cfg.getAwsS3BucketName()).isNull();
+        assertThat(cfg.getAwsS3AccessKey()).isNull();
+        assertThat(cfg.getAwsS3SecretAccessKey()).isNull();
+    }
+
+    @Test
+    public void updated_nullDictionary_doesNotThrow() {
+        GraphQLWebsitesConfig cfg = freshConfig();
+
+        assertThatCode(() -> cfg.updated(null)).doesNotThrowAnyException();
+    }
+
+    // -------------------------------------------------------------------------
+    // All keys present → configured
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void updated_allKeysPresent_isConfigured() throws Exception {
+        // Arrange
+        GraphQLWebsitesConfig cfg = freshConfig();
+        Hashtable<String, Object> dict = allKeys("us-east-1", "my-bucket", "AKID", "secret");
+
+        // Act
+        cfg.updated(dict);
+
+        // Assert
+        assertThat(cfg.isConfigured()).isTrue();
+    }
+
+    @Test
+    public void updated_allKeysPresent_gettersReturnExpectedValues() throws Exception {
+        // Arrange
+        GraphQLWebsitesConfig cfg = freshConfig();
+        cfg.updated(allKeys("eu-west-1", "test-bucket", "key123", "secret456"));
+
+        // Assert
+        assertThat(cfg.getAwsS3Region()).isEqualTo("eu-west-1");
+        assertThat(cfg.getAwsS3BucketName()).isEqualTo("test-bucket");
+        assertThat(cfg.getAwsS3AccessKey()).isEqualTo("key123");
+        assertThat(cfg.getAwsS3SecretAccessKey()).isEqualTo("secret456");
+    }
+
+    // -------------------------------------------------------------------------
+    // One key missing → not configured
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void updated_missingRegion_isNotConfigured() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        Hashtable<String, Object> dict = allKeys("us-east-1", "bucket", "key", "secret");
+        dict.remove(GraphQLWebsitesConfig.AWS_S3_REGION);
+
+        cfg.updated(dict);
+
+        assertThat(cfg.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void updated_missingBucketName_isNotConfigured() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        Hashtable<String, Object> dict = allKeys("us-east-1", "bucket", "key", "secret");
+        dict.remove(GraphQLWebsitesConfig.AWS_S3_BUCKET_NAME);
+
+        cfg.updated(dict);
+
+        assertThat(cfg.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void updated_missingAccessKey_isNotConfigured() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        Hashtable<String, Object> dict = allKeys("us-east-1", "bucket", "key", "secret");
+        dict.remove(GraphQLWebsitesConfig.AWS_S3_ACCESS_KEY);
+
+        cfg.updated(dict);
+
+        assertThat(cfg.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void updated_missingSecretKey_isNotConfigured() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        Hashtable<String, Object> dict = allKeys("us-east-1", "bucket", "key", "secret");
+        dict.remove(GraphQLWebsitesConfig.AWS_S3_SECRET_ACCESS_KEY);
+
+        cfg.updated(dict);
+
+        assertThat(cfg.isConfigured()).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Blank value excluded → not configured
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void updated_blankRegion_isNotConfigured() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        Hashtable<String, Object> dict = allKeys("   ", "bucket", "key", "secret");
+
+        cfg.updated(dict);
+
+        assertThat(cfg.isConfigured()).isFalse();
+        assertThat(cfg.getAwsS3Region()).isNull();
+    }
+
+    @Test
+    public void updated_blankBucketName_isNotConfigured() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        Hashtable<String, Object> dict = allKeys("us-east-1", "", "key", "secret");
+
+        cfg.updated(dict);
+
+        assertThat(cfg.isConfigured()).isFalse();
+        assertThat(cfg.getAwsS3BucketName()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Snapshot atomicity: second updated() replaces first completely
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void updated_calledTwice_secondCallReplacesFirst() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        cfg.updated(allKeys("us-east-1", "bucket1", "key1", "sec1"));
+        cfg.updated(allKeys("ap-northeast-1", "bucket2", "key2", "sec2"));
+
+        assertThat(cfg.getAwsS3Region()).isEqualTo("ap-northeast-1");
+        assertThat(cfg.getAwsS3BucketName()).isEqualTo("bucket2");
+        assertThat(cfg.isConfigured()).isTrue();
+    }
+
+    @Test
+    public void updated_configuredThenNull_becomesNotConfigured() throws Exception {
+        GraphQLWebsitesConfig cfg = freshConfig();
+        cfg.updated(allKeys("us-east-1", "bucket", "key", "secret"));
+        assertThat(cfg.isConfigured()).isTrue();
+
+        cfg.updated(null);
+
+        assertThat(cfg.isConfigured()).isFalse();
+        assertThat(cfg.getAwsS3Region()).isNull();
+    }
+}

--- a/src/test/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurityTest.java
+++ b/src/test/java/org/jahia/community/graphql/provider/dxm/extensions/websites/PathSecurityTest.java
@@ -1,7 +1,13 @@
 package org.jahia.community.graphql.provider.dxm.extensions.websites;
 
+import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -15,6 +21,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class PathSecurityTest {
 
     private final Path baseDir = Paths.get("/var/jahia/exports").toAbsolutePath().normalize();
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    // -------------------------------------------------------------------------
+    // Original lexical tests (must continue to pass unchanged)
+    // -------------------------------------------------------------------------
 
     @Test
     public void resolveContained_simpleChild_returnsContainedPath() {
@@ -83,5 +96,102 @@ public class PathSecurityTest {
         // /var/jahia/exports-other must NOT be considered inside /var/jahia/exports
         Path tricky = Paths.get("/var/jahia/exports-other/file").toAbsolutePath().normalize();
         assertThat(PathSecurity.isContained(baseDir, tricky)).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Item K: new cases for symlink hardening, null-byte, dot-only, new file
+    // -------------------------------------------------------------------------
+
+    /**
+     * A symlink placed inside the base directory that points to an outside target must
+     * be rejected.  The test is skipped gracefully if the filesystem or OS does not
+     * support symbolic links (e.g. some Windows CI environments).
+     */
+    @Test
+    public void resolveContained_symlinkInsideBasePointingOutside_isRejected() throws IOException {
+        // Arrange: set up a real temp directory as the "base"
+        File baseFile = tmp.newFolder("exports");
+        Path realBase = baseFile.toPath().toRealPath();
+
+        // Create the outside target directory that the symlink will point to
+        File outsideTarget = tmp.newFolder("outside");
+
+        // Attempt to create a symlink inside the base pointing at the outside dir
+        Path symlinkPath = realBase.resolve("escape-link");
+        try {
+            Files.createSymbolicLink(symlinkPath, outsideTarget.toPath().toRealPath());
+        } catch (UnsupportedOperationException | IOException e) {
+            // Filesystem does not support symlinks — skip this test
+            Assume.assumeNoException("Skipping: filesystem does not support symlinks", e);
+        }
+
+        // Act / Assert: resolveContained must reject "escape-link" because its real path
+        // lands outside the real base
+        assertThatThrownBy(() -> PathSecurity.resolveContained(realBase, "escape-link"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /**
+     * A child containing a null byte must be rejected (C-string truncation attack).
+     */
+    @Test
+    public void resolveContained_nullByteInChild_isRejected() {
+        assertThatThrownBy(() -> PathSecurity.resolveContained(baseDir, "valid\0/../../escape"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null bytes");
+    }
+
+    /**
+     * A child of "." resolves to the base directory itself.
+     * Expected behaviour: ALLOWED — the caller receives the base dir path.
+     * Rationale: "." is a valid relative path meaning "current directory" (the base),
+     * and {@code base.resolve(".").normalize()} == {@code base}.  No traversal occurs.
+     */
+    @Test
+    public void resolveContained_dotOnlyChild_resolvesToBase() throws IOException {
+        File baseFile = tmp.newFolder("exports");
+        Path realBase = baseFile.toPath().toRealPath();
+
+        Path resolved = PathSecurity.resolveContained(realBase, ".");
+
+        assertThat(resolved).isEqualTo(realBase);
+        assertThat(PathSecurity.isContained(realBase, resolved)).isTrue();
+    }
+
+    /**
+     * A path fragment that names a file that does NOT yet exist (it will be created later
+     * by the export) must still be ALLOWED — the real-path canonicalization must not
+     * break creation of new files under the base.
+     */
+    @Test
+    public void resolveContained_newNonExistentFileUnderBase_isAllowed() throws IOException {
+        // Arrange: a real base that exists on disk
+        File baseFile = tmp.newFolder("exports");
+        Path realBase = baseFile.toPath().toRealPath();
+
+        // The target file does not exist yet
+        String newFileName = "new-export-20991231.zip";
+
+        // Act / Assert: must NOT throw
+        Path resolved = PathSecurity.resolveContained(realBase, newFileName);
+
+        assertThat(resolved).isEqualTo(realBase.resolve(newFileName));
+        assertThat(PathSecurity.isContained(realBase, resolved)).isTrue();
+    }
+
+    /**
+     * {@link PathSecurity#toRealPathOfExistingAncestor} returns the real path of the
+     * nearest existing ancestor when the full path does not exist.
+     */
+    @Test
+    public void toRealPathOfExistingAncestor_nonExistentChild_returnsRealParent() throws IOException {
+        File baseFile = tmp.newFolder("exports");
+        Path realBase = baseFile.toPath().toRealPath();
+        Path nonExistent = realBase.resolve("does-not-exist.zip");
+
+        Path ancestor = PathSecurity.toRealPathOfExistingAncestor(nonExistent);
+
+        // The existing ancestor is the base dir itself
+        assertThat(ancestor).isEqualTo(realBase);
     }
 }


### PR DESCRIPTION
## Summary
Blind review (architecture, security, code quality/SonarQube, tests, documentation) of `graphql-extension-websites` (site create/delete/export/import + export-to-S3 GraphQL mutations) followed by hardening. No frontend → no ergonomy/accessibility surface.

### Security
- All mutations confirmed gated by `@GraphQLRequiresPermission("websitesAdmin")`; permission + assignable role shipped via JCR import (pre-existing).
- **PathSecurity symlink hardening**: containment was lexical-only (`normalize()` doesn't resolve symlinks). Now also canonicalizes via `toRealPath()` against the deepest existing ancestor, so a symlink inside the base dir can't escape — while still allowing creation of not-yet-existing export files. `exportWebsite` additionally refuses to delete a symlinked target.
- Config: removed per-key INFO logging and the public `getConfig()` map exposure (avoids any AWS-credential leak surface); README example no longer passes credentials inline in GraphQL (uses the `.cfg`/ConfigurationAdmin mechanism).

### Correctness / quality
- Fixed a real bug: `deleteSiteByKey` "site not found" logged via `String.format` mismatch → `MissingFormatArgumentException`; now SLF4J-parameterized (Sonar S2629).
- Narrowed an over-broad `catch (Exception)` in `importSite`; `importFiles` now reports success so a silently-failed import isn't counted; removed a dead `throws IOException`.
- `GraphQLWebsitesConfig`: replaced the non-atomic dual-`volatile` (map + flag) with a single immutable `ConfigSnapshot` published via one volatile reference (atomic reads); `@SuppressWarnings(java:S3077)` documents the correct idiom.
- `exportAllSites` path now built with `Paths.get(...).normalize()` (no string concatenation); `ImportInfo` gained `serialVersionUID`.
- SonarQube gate cleared (S2629, S1141 nested-try extraction, S3077, S125).

### Tests
- 27 Java unit tests (added `PathSecurity` symlink/null-byte/dot-only/new-file cases and a full `GraphQLWebsitesConfig` suite).

## Quality gates
- SonarQube quality gate: **OK** (0 new issues).
- `mvn clean install` (JDK 17 / Java 11): BUILD SUCCESS, 27/27 tests.
- Cypress: **6/7** — the `Permissions` spec passes **2/2**; create/delete/import + `exportAllSites` pass. The one failing test (`exportWebsite` of `systemsite`) is a pre-existing `@GraphQLAsync` timing issue: the async field resolves to `undefined` in the harness with no server-side error, and it still fails after reverting all of this PR's `exportWebsite` changes — i.e. not a regression. Flagged for follow-up.

### Deferred (documented in README)
- `exportAllSites` privilege-scope (runs as root, exports entire instance) — documented; re-scoping to a stronger permission left for a follow-up to avoid breaking the admin role.
- Static `BundleUtils.getOsgiService` → `@Reference` rearchitecture; pre-import zip-slip/archive validation (delegated to Jahia core, admin-gated).

## Test plan
- [x] `mvn clean install` + 27 unit tests
- [x] SonarQube gate OK
- [x] Cypress 6/7 (Permissions 2/2; pre-existing exportWebsite async flake documented)